### PR TITLE
Allow use of promise.finally as a last step

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -43,6 +43,7 @@
     "security/detect-unsafe-regex": 0,
 
     "promise/always-return": 0,
+    "promise/catch-or-return": [2, { "allowFinally": true }],
     "promise/no-callback-in-promise": 0,
     "promise/no-nesting": 0,
 


### PR DESCRIPTION
Previously, this was forbidden:
```javascript
myPromise
  .catch(err => handleError(err))
  .finally(() => cleanup())
```

Note that the rule still requires that `.catch` exists before the `.finally`