### PR TITLE
Enforce trailing commas on multi-line comma-separated values

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -35,7 +35,13 @@
     "quote-props": [2, "as-needed", { "keywords": true, "numbers": true, "unnecessary": false }],
     "quotes": ["error", "single", { "avoidEscape": true, "allowTemplateLiterals": true }],
     "require-atomic-updates": 2,
-    "comma-dangle": ["error", "always-multiline"],
+    "comma-dangle": ["error", {
+      "arrays": "always-multiline",
+      "objects": "always-multiline",
+      "imports": "always-multiline",
+      "exports": "always-multiline",
+      "functions": "never"
+    }],
 
     "unicorn/catch-error-name": ["error", {"name": "err"}],
     "unicorn/consistent-function-scoping": 0,


### PR DESCRIPTION
Not having trailing commas a bit of a peeve of mine.

I usually get one or two issues regarding trailing commas when I'm rebasing a branch. It's also a common recurring problem with merges. ... and additionally, it clouds up the git history.

Consider adding another property to `myObj` here:
```JavaScript
const myObj = {
  foo: 'bar'
};
```

Yes, you _can_ put it above `foo: 'bar'` to avoid altering too many lines, but you shouldn't have to think about it.

Setting the `comma-dangle` rule to `always-multiline` will enforce trailing commas in the example above, but not in places where objects/arrays/function/_whatever you like_ are defined in a single line (for example `const myArr = [1, 2, 3];`). [Documentation](https://eslint.org/docs/rules/comma-dangle)

IIRC, the reason we dont have this rule at the moment is because some older browsers don't support trailing commas in the client side JS. But that is not an issue anymore now that we're defaulting to es6 anyway.

I would like to hear your opinions on this.

Yay/Nay?